### PR TITLE
Use resources to load QML files

### DIFF
--- a/app/source/main.cpp
+++ b/app/source/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
     QQmlContext *ctxt = view.rootContext();
     ctxt->setContextProperty("kaidan", &kaidan);
 
-    view.setSource(QUrl::fromLocalFile("main.qml"));
+    view.setSource(QUrl("qrc:/main.qml"));
     view.show();
 
     return app.exec();


### PR DESCRIPTION
QUrl::fromLocalFile() expects local file to exist thus it doesn't work with regular builds.