### PR TITLE
Update QtQuick Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Create a working directory
 
 Install dependencies to build Kaidan (example for Debian)
 
- *  `sudo apt-get install git-core cmake build-essential libstdc++-5-dev zlib1g-dev libglib2.0-dev libssl-dev libxml2-dev libcrypto++-dev libpthread-stubs0-dev libidn11-dev libminiupnpc-dev libnatpmp-dev libswiften-dev libboost-signals-dev libboost-system-dev libboost-thread-dev libboost-regex-dev libboost-program-options-dev libboost-filesystem-dev libboost-serialization-dev libboost-date-time-dev libqt5quick5 libqt5quickparticles5 libqt5quickwidgets5 libqt5qml5 libqt5network5 libqt5gui5 libqt5core5a qtdeclarative5-dev qt5-default qml-module-org-kde-kirigami`
+ *  `sudo apt-get install git-core cmake build-essential libstdc++-5-dev zlib1g-dev libglib2.0-dev libssl-dev libxml2-dev libcrypto++-dev libpthread-stubs0-dev libidn11-dev libminiupnpc-dev libnatpmp-dev libswiften-dev libboost-signals-dev libboost-system-dev libboost-thread-dev libboost-regex-dev libboost-program-options-dev libboost-filesystem-dev libboost-serialization-dev libboost-date-time-dev libqt5quick5 libqt5quickcontrols2-5 libqt5quickparticles5 libqt5quickwidgets5 libqt5qml5 libqt5network5 libqt5gui5 libqt5core5a qtdeclarative5-dev qt5-default qml-module-qtquick-controls2 qml-module-org-kde-kirigami`
 
 Get Kaidan source code
 

--- a/src/qml/LoginPage.qml
+++ b/src/qml/LoginPage.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick.Controls 2.0 as Controls
 import QtQuick.Layouts 1.2
 import org.kde.kirigami 1.0 as Kirigami
 import harbour.kaidan 1.0


### PR DESCRIPTION
When the debian package for Kirigami 2.0 is out, we can
also update Kirigami.