### PR TITLE
Rename settings file (kaidan/kaidan -> KaidanIM/kaidan)

### DIFF
--- a/src/Kaidan.cpp
+++ b/src/Kaidan.cpp
@@ -43,8 +43,8 @@ Kaidan::Kaidan(NetworkFactories* networkFactories, QObject *parent) :
 	// Restore login data
 	//
 
-	// init settings (-> "kaidan/kaidan.conf")
-	settings = new QSettings(QString(APPLICATION_NAME), QString(APPLICATION_NAME));
+	// init settings (-> "KaidanIM/kaidan.conf")
+	settings = new QSettings(QString(ORGANIZAITON_NAME), QString(APPLICATION_NAME));
 
 	if (settings->value("auth/jid").toString() != "")
 	{


### PR DESCRIPTION
I want to change this, because the default is so, too. #56 also saves the new db in `~/.local/share/KaidanIM/kaidan/...`.