### PR TITLE
CMake: Make i18n support optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ set(QT_MIN_VERSION "5.7.0")
 
 project(kaidan)
 
+# CMake options
+option(I18N "Enable i18n support" FALSE)
+
 # application name
 set(APPLICATION_ID "harbour.kaidan")
 set(APPLICATION_NAME "kaidan")
@@ -55,7 +58,9 @@ find_package(Boost REQUIRED)
 # Translation
 #
 
-include("${CMAKE_SOURCE_DIR}/i18n/CMakeLists.txt")
+if(I18N)
+	include("${CMAKE_SOURCE_DIR}/i18n/CMakeLists.txt")
+endif()
 
 #
 # Sources / Resources

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Get Kaidan source code
 Finally compile it
 
  * `mkdir kaidan/build ; cd kaidan/build`
- * `cmake ..`
+ * `cmake .. -DI18N=1`
  * `make -j<number of threads>`
 
 You can now run Kaidan:


### PR DESCRIPTION
It's minimally faster and you'll get a cleaner output if you disable i18n support. At the moment I don't know how to suppress the output of the qt linguist tools. I'd like to make it optional (and disabled per default). In the README, I added the option for turning it on.