### PR TITLE
Improve chat design

### DIFF
--- a/src/qml/ChatPage.qml
+++ b/src/qml/ChatPage.qml
@@ -61,7 +61,7 @@ Kirigami.Page {
 
 					width: 40
 					height: 40
-					radius: width*0.5
+					radius: width * 0.5
 					color: "grey"
 					visible: !sentByMe
 				}
@@ -71,7 +71,7 @@ Kirigami.Page {
 					border.width: 1
 					border.color: "#E1DFDF"
 					width: messageText.width + 10
-					height: messageText.height + 10
+					height: messageText.height + 2
 					color: sentByMe ? "lightgrey" : "steelblue"
 
 					Kirigami.Label {

--- a/src/qml/ChatPage.qml
+++ b/src/qml/ChatPage.qml
@@ -59,18 +59,23 @@ Kirigami.Page {
 				Rectangle {
 					id: avatar
 
-					width: height
-					height: parent.height
+					width: 40
+					height: 40
+					radius: width*0.5
 					color: "grey"
 					visible: !sentByMe
 				}
 
 				Rectangle {
-					width: 80
-					height: 40
+					radius: 2
+					border.width: 1
+					border.color: "#E1DFDF"
+					width: messageText.width + 10
+					height: messageText.height + 10
 					color: sentByMe ? "lightgrey" : "steelblue"
 
 					Kirigami.Label {
+						id: messageText
 						anchors.centerIn: parent
 						text: model.message
 						color: sentByMe ? "black" : "white"


### PR DESCRIPTION
This just fixes the rectangles in the background of a chat's messenges, and adds a few new design features like minimal rounded corners. If you don't like those, I will remove them from the pr to make the chat usable soon.

![screenshot_20170219_164034](https://cloud.githubusercontent.com/assets/13609393/23103851/2abb32e6-f6c2-11e6-8983-819773701c24.png)

Closes #13