### PR TITLE
Add roster add/remove contact functions

### DIFF
--- a/src/RosterController.cpp
+++ b/src/RosterController.cpp
@@ -18,17 +18,22 @@
  *  along with Kaidan. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// RosterController
 #include "RosterController.h"
-
+// C++
 #include <string.h>
-
+// Qt 5
 #include <QQmlContext>
 #include <QDebug>
 #include <QSqlError>
 #include <QSqlRecord>
 #include <QSqlQuery>
-
+// Kaidan
 #include "RosterModel.h"
+// Swiften
+#include <Swiften/Swiften.h>
+// Boost
+#include <boost/bind.hpp>
 
 RosterController::RosterController(QObject *parent) : QObject(parent)
 {
@@ -43,6 +48,7 @@ RosterController::~RosterController()
 void RosterController::setClient(Swift::Client *client_)
 {
 	client = client_;
+	iqRouter = client->getIQRouter();
 	xmppRoster = client->getRoster();
 	xmppRoster->onInitialRosterPopulated.connect(boost::bind(&RosterController::handleInitialRosterPopulated, this));
 }
@@ -74,7 +80,7 @@ void RosterController::handleRosterReceived(Swift::ErrorPayload::ref error_)
 
 		// create a vector containing all roster items
 		std::vector<Swift::XMPPRosterItem> rosterItems = xmppRoster->getItems();
-		// create a fitting iterator
+		// create an iterator for it
 		std::vector<Swift::XMPPRosterItem>::iterator it;
 
 		// add all contacts from the received roster
@@ -141,4 +147,49 @@ void RosterController::handleRosterCleared()
 	rosterModel->clearData();
 
 	emit rosterModelChanged();
+}
+
+void RosterController::addContact(const QString jid_, const QString name_)
+{
+	// the contact will be added to the model via. handleJidAdded
+
+	// generate a new ID for the subscription request
+	Swift::IDGenerator idGenerator;
+	std::string iqId = idGenerator.generateID();
+
+	// create a new roster item payload
+	Swift::RosterItemPayload addItemPayload;
+	addItemPayload.setJID(jid_.toStdString());
+	addItemPayload.setName(name_.toStdString());
+	addItemPayload.setSubscription(Swift::RosterItemPayload::None);
+
+	// add the new roster item payload to a new roster payload
+	boost::shared_ptr<Swift::RosterPayload> rosterPayload(new Swift::RosterPayload);
+	rosterPayload->addItem(addItemPayload);
+
+	// sent the request
+	iqRouter->sendIQ(
+		Swift::IQ::createRequest(Swift::IQ::Set, Swift::JID(), iqId, rosterPayload)
+	);
+}
+
+void RosterController::removeContact(const QString jid_)
+{
+	// the contact will be removed from the model via. handleJidRemoved
+
+	// generate new id for the request
+	Swift::IDGenerator idGenerator;
+	std::string iqId = idGenerator.generateID();
+
+	// create new roster payload, add roster item removal
+	boost::shared_ptr<Swift::RosterPayload> rosterPayload(new Swift::RosterPayload);
+	rosterPayload->addItem(Swift::RosterItemPayload(
+		Swift::JID(jid_.toStdString()), "",
+		Swift::RosterItemPayload::Remove
+	));
+
+	// send the remove request
+	iqRouter->sendIQ(
+		Swift::IQ::createRequest(Swift::IQ::Set, Swift::JID(), iqId, rosterPayload)
+	);
 }

--- a/src/RosterController.h
+++ b/src/RosterController.h
@@ -42,6 +42,8 @@ public:
 	void setClient(Swift::Client *client_);
 	void requestRosterFromClient();
 	RosterModel* getRosterModel();
+	Q_INVOKABLE void addContact(const QString jid_, const QString name_);
+	Q_INVOKABLE void removeContact(const QString);
 
 signals:
 	void rosterModelChanged();
@@ -54,6 +56,7 @@ private:
 	void handleJidUpdated(const Swift::JID &jid_, const std::string &name_, const std::vector<std::string>&);
 	void handleRosterCleared();
 	Swift::Client* client;
+	Swift::IQRouter *iqRouter;
 	Swift::XMPPRoster* xmppRoster;
 	RosterModel* rosterModel;
 };


### PR DESCRIPTION
This introduces the new QML-side functions:
`kaidan.rosterController.addContact(jid, name)`
`kaidan.rosterController.removeContact(jid)`

Currently they are not used.

In my tests there was just one problem: The roster (UI) doesn't refreshes when a contact was removed, but whenever a contact was added. (Idk why)