### PR TITLE
Add XEP-0280: Message Carbons

### DIFF
--- a/src/Kaidan.cpp
+++ b/src/Kaidan.cpp
@@ -32,6 +32,8 @@
 // gloox
 #include <gloox/rostermanager.h>
 #include <gloox/receipt.h>
+#include <gloox/forward.h>
+#include <gloox/carbons.h>
 // Kaidan
 #include "RosterModel.h"
 #include "MessageModel.h"
@@ -108,12 +110,14 @@ void Kaidan::mainConnect()
 	client->registerPresenceHandler(presenceHandler);
 
 	// Service Discovery
-	serviceDiscoveryManager = new ServiceDiscoveryManager(client->disco());
+	serviceDiscoveryManager = new ServiceDiscoveryManager(client, client->disco());
 
 	// Register Stanza Extensions
 	client->registerStanzaExtension(new gloox::Receipt(gloox::Receipt::Request));
 	client->registerStanzaExtension(new gloox::Receipt(gloox::Receipt::Received));
 	client->registerStanzaExtension(new gloox::DelayedDelivery(gloox::JID(), std::string("")));
+	client->registerStanzaExtension(new gloox::Forward());
+	client->registerStanzaExtension(new gloox::Carbons());
 
 	// Logging
 	client->logInstance().registerLogHandler(gloox::LogLevelDebug,

--- a/src/ServiceDiscoveryManager.h
+++ b/src/ServiceDiscoveryManager.h
@@ -28,11 +28,12 @@
 #include <gloox/client.h>
 #include <gloox/disco.h>
 #include <gloox/discohandler.h>
+#include <gloox/connectionlistener.h>
 
-class ServiceDiscoveryManager : gloox::DiscoHandler
+class ServiceDiscoveryManager : public gloox::DiscoHandler, public gloox::ConnectionListener
 {
 public:
-	ServiceDiscoveryManager(gloox::Disco *disco);
+	ServiceDiscoveryManager(gloox::Client *client, gloox::Disco *disco);
 	~ServiceDiscoveryManager();
 
 	void setFeaturesAndIdentity();
@@ -42,7 +43,12 @@ public:
 	void handleDiscoError(const gloox::JID &from, const gloox::Error *error, int context);
 	bool handleDiscoSet(const gloox::IQ &iq);
 
+	virtual void onConnect();
+	virtual void onDisconnect(gloox::ConnectionError error);
+	virtual bool onTLSConnect(const gloox::CertInfo &info);
+
 private:
+	gloox::Client *client;
 	gloox::Disco *disco;
 };
 


### PR DESCRIPTION
Message carbons allow you to receive the outgoing message of another client of the
same account. In short: messages are synced between the clients.

The handleMessage function of the MessageHandler can now handle both types of messages,
normal, direct messages by a contact and forwarded messages (possibly) written from the same
account.

Notfications and unread message counters are only used, if the message written by somebody
else, so you're not getting annoyed by notifications of your own messages. :)

Closes #116.