### PR TITLE
Use Q_PROPERTIES instead of SQL fields for avatars

### DIFF
--- a/src/AvatarFileStorage.h
+++ b/src/AvatarFileStorage.h
@@ -20,13 +20,16 @@
 #ifndef AVATARFILESTORAGE_H
 #define AVATARFILESTORAGE_H
 
+#include <QObject>
 #include <QString>
 #include <QMap>
 
-class AvatarFileStorage
+class AvatarFileStorage : public QObject
 {
+	Q_OBJECT
+
 public:
-	AvatarFileStorage();
+	AvatarFileStorage(QObject *parent = 0);
 	~AvatarFileStorage();
 
 	struct AddAvatarResult {
@@ -38,11 +41,16 @@ public:
 		bool newWritten = false;
 	};
 
-	bool hasAvatarHash(const QString &hash) const;
 	AddAvatarResult addAvatar(const QString &jid, const QByteArray &avatar);
+	QString getAvatarPathOfJid(const QString &jid) const;
+	bool hasAvatarHash(const QString &hash) const;
 	QString getAvatarPath(const QString &hash) const;
-	QString getAvatarPathForJid(const QString &jid) const;
-	QString getHashForJid(const QString &jid) const;
+
+	Q_INVOKABLE QString getHashOfJid(const QString &jid) const;
+	Q_INVOKABLE QString getAvatarUrl(const QString &jid) const;
+
+signals:
+	void avatarIdsChanged();
 
 private:
 	void saveAvatarsFile();

--- a/src/Kaidan.cpp
+++ b/src/Kaidan.cpp
@@ -60,6 +60,9 @@ Kaidan::Kaidan(QObject *parent) : QObject(parent)
 	rosterModel = new RosterModel(database->getDatabase());
 	xmlLogHandler = new XmlLogHandler();
 	avatarStorage = new AvatarFileStorage();
+	// Connect the avatar changed signal of the avatarStorage with the NOTIFY signal
+	// of the Q_PROPERTY for the avatar storage (so all avatars are updated in QML)
+	connect(avatarStorage, &AvatarFileStorage::avatarIdsChanged, this, &Kaidan::avatarStorageChanged);
 
 	// client package fetch timer
 	packageFetchTimer = new QTimer(this);
@@ -311,6 +314,11 @@ RosterModel* Kaidan::getRosterModel()
 MessageModel* Kaidan::getMessageModel()
 {
 	return messageModel;
+}
+
+AvatarFileStorage* Kaidan::getAvatarStorage()
+{
+	return avatarStorage;
 }
 
 bool Kaidan::getConnectionState() const

--- a/src/Kaidan.h
+++ b/src/Kaidan.h
@@ -46,6 +46,7 @@ class Kaidan : public QObject, public gloox::ConnectionListener
 
 	Q_PROPERTY(RosterModel* rosterModel READ getRosterModel NOTIFY rosterModelChanged)
 	Q_PROPERTY(MessageModel* messageModel READ getMessageModel NOTIFY messageModelChanged)
+	Q_PROPERTY(AvatarFileStorage* avatarStorage READ getAvatarStorage NOTIFY avatarStorageChanged)
 	Q_PROPERTY(bool connectionState READ getConnectionState NOTIFY connectionStateConnected NOTIFY connectionStateDisconnected)
 	Q_PROPERTY(QString jid READ getJid WRITE setJid NOTIFY jidChanged)
 	Q_PROPERTY(QString jidResource READ getJidResource WRITE setJidResource NOTIFY jidResourceChanged)
@@ -78,6 +79,7 @@ public:
 	void setChatPartner(QString);
 	RosterModel* getRosterModel();
 	MessageModel* getMessageModel();
+	AvatarFileStorage* getAvatarStorage();
 
 	virtual void onConnect();
 	virtual void onDisconnect(gloox::ConnectionError error);
@@ -86,6 +88,7 @@ public:
 signals:
 	void rosterModelChanged();
 	void messageModelChanged();
+	void avatarStorageChanged();
 	void vCardControllerChanged();
 	void connectionStateConnected();
 	void connectionStateDisconnected();

--- a/src/qml/RosterPage.qml
+++ b/src/qml/RosterPage.qml
@@ -42,7 +42,9 @@ Kirigami.ScrollablePage {
 			name: model.name ? model.name : model.jid
 			lastMessage: model.lastMessage
 			unreadMessages: model.unreadMessages
-			avatarImagePath: model.avatarHash ? kaidan.getAvatarPath(model.avatarHash) : kaidan.getResourcePath("images/fallback-avatar.svg")
+			avatarImagePath: kaidan.avatarStorage.getHashOfJid(model.jid) != "" ?
+					 kaidan.avatarStorage.getAvatarUrl(model.jid) :
+					 kaidan.getResourcePath("images/fallback-avatar.svg")
 
 			onClicked: {
 				// first push the chat page


### PR DESCRIPTION
Will be needed to use individual (automatically updating) avatars e.g. on a profile page or for the own avatar.