### PR TITLE
getResourcePath: Only use source path in dbg builds

### DIFF
--- a/src/Kaidan.cpp
+++ b/src/Kaidan.cpp
@@ -288,8 +288,10 @@ QString Kaidan::getResourcePath(QString name_)
 	pathList << QCoreApplication::applicationDirPath() + QString("/../share/") + QString(APPLICATION_NAME);
 	// get the standard app data locations for current platform
 	pathList << QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-	// add build directory
+#ifndef NDEBUG
+	// add source directory (only for debug builds)
 	pathList << QString(DEBUG_SOURCE_PATH) + QString("/data"); // append debug directory
+#endif
 
 	// search for file in directories
 	for (int i = 0; i < pathList.size(); i++) {


### PR DESCRIPTION
Before kaidan always search in the source path (also on real installations),
now kaidan only searches in the DEBUG_SOURCE_PATH, if the current build is a
debug build.