### PR TITLE
Don't force the QtQuickControls Theme

### DIFF
--- a/misc/qtquickcontrols2.conf
+++ b/misc/qtquickcontrols2.conf
@@ -1,6 +1,3 @@
-[Controls]
-Style=Material
-
 [Universal]
 Theme=System
 Accent=Green

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,9 +132,13 @@ int main(int argc, char *argv[])
 	//
 	// QML-GUI
 	//
+
 #ifndef SAILFISH_OS
 	// QtQuickControls2 Style
-	qputenv("QT_QUICK_CONTROLS_STYLE", "Material");
+	if (qgetenv("QT_QUICK_CONTROLS_STYLE").isEmpty()) {
+		qDebug() << "QT_QUICK_CONTROLS_STYLE not set, setting to Material";
+		qputenv("QT_QUICK_CONTROLS_STYLE", "Material");
+	}
 #endif
 
 	QQmlApplicationEngine engine;

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -31,7 +31,7 @@ Kirigami.ApplicationWindow {
 	// signals
 	signal addContactDialogRequested()
 
-	header: Kirigami.ToolBarApplicationHeader {
+	header: Kirigami.ApplicationHeader {
 		preferredHeight: Kirigami.Units.gridUnit * 2.25
 	}
 


### PR DESCRIPTION
Probably especially useful for Plasma Mobile, as it has it's own theme.
This also enables Kaidan to use the system color sheme.
(This change may need discussion)