### PR TITLE
Fix RichText labels in Plasma (Mobile)

### DIFF
--- a/src/qml/AboutSheet.qml
+++ b/src/qml/AboutSheet.qml
@@ -60,24 +60,28 @@ Kirigami.OverlaySheet {
 
 		Kirigami.Heading {
 			text: "Kaidan " + kaidan.getVersionString()
+			textFormat: Text.PlainText
 			Layout.fillWidth: true
 			horizontalAlignment: Qt.AlignHCenter
 		}
 
 		Controls.Label {
 			text: "<i>" + qsTr("A simple, user-friendly Jabber/XMPP client") + "</i>"
+			textFormat: Text.RichText
 			Layout.fillWidth: true
 			horizontalAlignment: Qt.AlignHCenter
 		}
 
 		Controls.Label {
 			text: "<b>" + qsTr("License:") + "</b> GPLv3+ / CC BY-SA 4.0"
+			textFormat: Text.RichText
 			Layout.fillWidth: true
 			horizontalAlignment: Qt.AlignHCenter
 		}
 
 		Controls.Label {
 			text: "Copyright © 2016-2018\nKaidan developers and contributors"
+			textFormat: Text.PlainText
 			wrapMode: Text.WordWrap
 			Layout.fillWidth: true
 			horizontalAlignment: Qt.AlignHCenter

--- a/src/qml/LoginPage.qml
+++ b/src/qml/LoginPage.qml
@@ -99,19 +99,26 @@ Kirigami.Page {
 			// Connect button
 			Controls.Button {
 				id: connectButton
-				text: isRetry ? qsTr("Retry") : qsTr("Connect")
 				Layout.columnSpan: 2
 				Layout.alignment: Qt.AlignRight
+				Layout.minimumWidth: connectLabel.width
 				onClicked: {
 					// disable the button
 					connectButton.enabled = false;
 					// indicate that we're connecting now
-					connectButton.text = "<i>" + qsTr("Connecting…") + "</i>";
+					connectLabel.text = "<i>" + qsTr("Connecting…") + "</i>";
 
 					// connect to given account data
 					kaidan.jid = jidField.text;
 					kaidan.password = passField.text;
 					kaidan.mainConnect();
+				}
+
+				Controls.Label {
+					id: connectLabel
+					anchors.centerIn: connectButton
+					text: isRetry ? qsTr("Retry") : qsTr("Connect")
+					textFormat: Text.RichText
 				}
 			}
 		}

--- a/src/qml/RosterRemoveContactSheet.qml
+++ b/src/qml/RosterRemoveContactSheet.qml
@@ -37,7 +37,7 @@ Kirigami.OverlaySheet {
 	property string jid;
 
 	onSheetOpenChanged: {
-		infoLabel.text = qsTr("Do you really want to delete the contact \"%1\" from your roster?").arg(jid);
+		infoLabel.text = qsTr("Do you really want to delete the contact <%1> from your roster?").arg(jid);
 	}
 
 	ColumnLayout {
@@ -50,6 +50,7 @@ Kirigami.OverlaySheet {
 		Controls.Label {
 			id: infoLabel
 			text: ""
+			textFormat: Text.PlainText
 			wrapMode: Text.WordWrap
 
 			Layout.fillWidth: true
@@ -68,7 +69,6 @@ Kirigami.OverlaySheet {
 			Controls.Button {
 				text: qsTr("Delete")
 				onClicked: {
-					print(jid);
 					kaidan.removeContact(jid);
 					close();
 				}

--- a/src/qml/elements/ChatMessage.qml
+++ b/src/qml/elements/ChatMessage.qml
@@ -80,6 +80,7 @@ Row {
 				topPadding: Kirigami.Units.gridUnit * 0.5
 				bottomPadding: Kirigami.Units.gridUnit * 0.2
 				text: messageBody
+				textFormat: Text.PlainText
 				wrapMode: Text.Wrap
 				color: sentByMe ? "black" : "white"
 			}

--- a/src/qml/elements/RosterListItem.qml
+++ b/src/qml/elements/RosterListItem.qml
@@ -62,6 +62,7 @@ Kirigami.SwipeListItem {
 				// contact name
 				Kirigami.Heading {
 					text: name
+					textFormat: Text.PlainText
 					level: 3
 					Layout.fillWidth: true
 				}
@@ -70,6 +71,7 @@ Kirigami.SwipeListItem {
 			Controls.Label {
 				Layout.fillWidth: true
 				text: kaidan.removeNewLinesFromString(lastMessage);
+				textFormat: Text.PlainText
 			}
 		}
 

--- a/src/qml/elements/RosterListItem.qml
+++ b/src/qml/elements/RosterListItem.qml
@@ -62,7 +62,7 @@ Kirigami.SwipeListItem {
 			// contact name
 			Kirigami.Heading {
 				text: name
-        textFormat: Text.PlainText
+				textFormat: Text.PlainText
 				elide: Text.ElideRight
 				maximumLineCount: 1
 				level: 3


### PR DESCRIPTION
This adds explicit textFormat settings in most labels, so labels are always
parsed, if wanted and never if not. So now, the messages aren't parsed anymore,
so the "send image hack" won't work anymore. This is also for security reasons,
because you probably don't want your system to always check any incoming links
in img tags.