### PR TITLE
Fix font sizing

### DIFF
--- a/src/qml/elements/ChatMessage.qml
+++ b/src/qml/elements/ChatMessage.qml
@@ -90,6 +90,7 @@ RowLayout {
 				text: messageBody
 				textFormat: Text.PlainText
 				wrapMode: Text.Wrap
+				font.pixelSize: 16
 				color: sentByMe ? "black" : "white"
 			}
 

--- a/src/qml/elements/RosterListItem.qml
+++ b/src/qml/elements/RosterListItem.qml
@@ -76,6 +76,7 @@ Kirigami.SwipeListItem {
 				maximumLineCount: 1
 				text: kaidan.removeNewLinesFromString(lastMessage);
 				textFormat: Text.PlainText
+				font.pixelSize: 16
 			}
 		}
 


### PR DESCRIPTION
As promised earlier, I explored font sizing. For me, this change fixes font sizes to make message text easier to read (for comparison, I used Telegram):

![screenshot_20180212_192301](https://user-images.githubusercontent.com/11175213/36226800-ed5aee5c-11df-11e8-8000-b92869cfb1fb.png)
<img src="https://user-images.githubusercontent.com/11175213/36226919-5ba911b8-11e0-11e8-849c-0f320f87d5dd.png" width="500">

Please, verify that it improves font sizes for you, too.