### PR TITLE
Fix not connecting on the first time

### DIFF
--- a/src/ClientThread.cpp
+++ b/src/ClientThread.cpp
@@ -66,8 +66,8 @@ ClientThread::ClientThread(RosterModel *rosterModel, MessageModel *messageModel,
 	// Set custom thread name
 	setObjectName("XmppClient");
 
-	client = new gloox::Client(gloox::JID(creds.jid.toStdString()),
-	                           creds.password.toStdString());
+	client = new GlooxClient(gloox::JID(creds.jid.toStdString()),
+	                         creds.password.toStdString());
 	client->bindResource(creds.jidResource.toStdString()); // set resource / device name
 	client->setTls(gloox::TLSRequired); // require encryption
 
@@ -142,7 +142,8 @@ void ClientThread::setCredentials(Credentials creds)
 	this->creds = creds;
 
 	client->setUsername(gloox::JID(creds.jid.toStdString()).username());
-	client->setServer(gloox::JID(creds.jid.toStdString()).server());
+	client->setServer(gloox::JID(creds.jid.toStdString()).serverRaw());
+	client->setJidServer(gloox::JID(creds.jid.toStdString()).server());
 	client->setPassword(creds.password.toStdString());
 	client->unbindResource(client->resource());
 	client->bindResource(creds.jidResource.toStdString());

--- a/src/ClientThread.h
+++ b/src/ClientThread.h
@@ -31,6 +31,8 @@
 #ifndef CLIENTTHREAD_H
 #define CLIENTTHREAD_H
 
+// gloox
+#include <gloox/client.h>
 // Qt
 #include <QMutex>
 #include <QThread>
@@ -56,7 +58,25 @@ class QSettings;
 using namespace Enums;
 
 /**
- * A class controlling the thread used for the XMPP connection.
+ * @class KaidanClient Needed to replace server after first connection
+ */
+class GlooxClient : public gloox::Client
+{
+public:
+	GlooxClient(gloox::JID jid, std::string password, int port = -1)
+	            : gloox::Client(jid, password, port)
+	{
+	}
+
+	void setJidServer(const std::string &server)
+	{
+		m_jid.setServer(server);
+	}
+};
+
+/**
+ * @class ClientThread A class controlling the thread used for the XMPP
+ * connection.
  * 
  * @see ClientWorker
  */
@@ -213,7 +233,7 @@ private:
 	AvatarFileStorage *avatarStorage;
 	Credentials creds;
 
-	gloox::Client *client;
+	GlooxClient *client;
 	ClientWorker *worker;
 	RosterManager *rosterManager;
 	MessageSessionHandler *messageSessionHandler;

--- a/src/ClientWorker.cpp
+++ b/src/ClientWorker.cpp
@@ -40,7 +40,7 @@
 // interval in seconds in which a new connection will be tryed
 static const unsigned int RECONNECT_INTERVAL = 5000;
 
-ClientWorker::ClientWorker(gloox::Client* client, ClientThread *controller,
+ClientWorker::ClientWorker(GlooxClient* client, ClientThread *controller,
 	QObject* parent) : QObject(parent), client(client), controller(controller)
 {
 	client->registerConnectionListener(this);

--- a/src/ClientWorker.h
+++ b/src/ClientWorker.h
@@ -37,11 +37,8 @@
 // gloox
 #include <gloox/connectionlistener.h>
 
-namespace gloox {
-	class Client;
-}
-
 class ClientThread;
+class GlooxClient;
 
 /**
  * The ClientWorker is used as a QObject-based worker on the ClientThread.
@@ -58,7 +55,7 @@ public:
 	 * @param controller The ClientThread instance for emitting signals.
 	 * @param parent Optional QObject-based parent.
 	 */
-	ClientWorker(gloox::Client *client, ClientThread *contoller,
+	ClientWorker(GlooxClient *client, ClientThread *contoller,
 	             QObject *parent = nullptr);
 
 	~ClientWorker();
@@ -114,7 +111,7 @@ private:
 	 */
 	void reconnect();
 
-	gloox::Client *client;
+	GlooxClient *client;
 	ClientThread *controller;
 	QTimer reconnectTimer;
 };


### PR DESCRIPTION
This fixes that the server wasn't changed after the first connection. The
problem was that gloox::Client::setServer() only sets the server for connecting
to, not the JID that is used to for authenticating on the server. There's a
comment in the documentation that says to change the server manually by getting
a reference of the jid in the client, but that doesn't work since the returned
jid is marked as const.