### PR TITLE
Use passive notifications when online actions fail

### DIFF
--- a/src/Kaidan.cpp
+++ b/src/Kaidan.cpp
@@ -189,29 +189,32 @@ quint8 Kaidan::getDisconnReason() const
 
 void Kaidan::sendMessage(QString jid, QString message)
 {
-	// TODO: Add offline message cache
-	if (client->isConnected())
+	if (client->isConnected()) {
 		emit client->sendMessageRequested(jid, message);
-	else
-		qWarning() << "[main] Couldn't send message, because not being connected.";
+	} else {
+		emit passiveNotificationRequested(tr("Could not send message, because not being connected."));
+		qWarning() << "[main] Could not send message, because not being connected.";
+	}
 }
 
 void Kaidan::addContact(QString jid, QString nick)
 {
-	// TODO: Add an error notification/message if not connected
-	if (client->isConnected())
+	if (client->isConnected()) {
 		emit client->addContactRequested(jid, nick);
-	else
-		qWarning() << "[main] Couldn't add contact, because not being connected.";
+	} else {
+		emit passiveNotificationRequested(tr("Could not add contact, because not being connected."));
+		qWarning() << "[main] Could not add contact, because not being connected.";
+	}
 }
 
 void Kaidan::removeContact(QString jid)
 {
-	// TODO: Add an error notification/message if not connected
-	if (client->isConnected())
+	if (client->isConnected()) {
 		emit client->removeContactRequested(jid);
-	else
-		qWarning() << "[main] Couldn't remove contact, because not being connected.";
+	} else {
+		emit passiveNotificationRequested(tr("Could not remove contact, because not being connected."));
+		qWarning() << "[main] Could not remove contact, because not being connected.";
+	}
 }
 
 QString Kaidan::getResourcePath(QString name) const
@@ -239,7 +242,7 @@ QString Kaidan::getResourcePath(QString name) const
 			return QString("file://") + directory.absoluteFilePath(name);
 		}
 	}
-	
+
 	// on Android, we want to fetch images from the application resources
 	if (QFile::exists(":/" + name))
 		return QString("qrc:/" + name);

--- a/src/Kaidan.h
+++ b/src/Kaidan.h
@@ -302,6 +302,11 @@ signals:
 	 */
 	void logInWorked();
 
+	/**
+	 * Show passive notification
+	 */
+	void passiveNotificationRequested(QString text);
+
 private:
 	void connectDatabases();
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -71,6 +71,10 @@ Kirigami.ApplicationWindow {
 	Component {id: loginPage; LoginPage {}}
 	Component {id: rosterPage; RosterPage {}}
 
+	function passiveNotification(text) {
+		showPassiveNotification(text, "long")
+	}
+
 	function openLogInPage() {
 		// close all pages (we don't know on which page we're on,
 		// thus we don't use replace)
@@ -93,8 +97,9 @@ Kirigami.ApplicationWindow {
 	}
 
 	Component.onCompleted: {
-		kaidan.newCredentialsNeeded.connect(openLogInPage);
-		kaidan.logInWorked.connect(closeLogInPage);
+		kaidan.passiveNotificationRequested.connect(passiveNotification)
+		kaidan.newCredentialsNeeded.connect(openLogInPage)
+		kaidan.logInWorked.connect(closeLogInPage)
 
 		// push roster page (trying normal start up)
 		pageStack.push(rosterPage)


### PR DESCRIPTION
This will throw a Kirigami passive notification, whenever you try to add or
remove a contact or send a message when being offline. It uses the "long" preset
for the timeout.