### PR TITLE
Encode passwords in base64 to make them not directly visible

### DIFF
--- a/src/ClientWorker.cpp
+++ b/src/ClientWorker.cpp
@@ -106,7 +106,7 @@ void ClientWorker::onConnect()
 	// accept credentials and save them
 	controller->creds.isFirstTry = false;
 	controller->settings->setValue("auth/jid", controller->creds.jid);
-	controller->settings->setValue("auth/password", controller->creds.password);
+	controller->settings->setValue("auth/password", QString::fromUtf8(controller->creds.password.toUtf8().toBase64()));
 }
 
 void ClientWorker::onDisconnect(gloox::ConnectionError error)

--- a/src/Kaidan.cpp
+++ b/src/Kaidan.cpp
@@ -73,7 +73,7 @@ Kaidan::Kaidan(QGuiApplication *app, QObject *parent) : QObject(parent)
 
 	creds.jid = settings->value("auth/jid").toString();
 	creds.jidResource = settings->value("auth/resource").toString();
-	creds.password = settings->value("auth/password").toString();
+	creds.password = QString(QByteArray::fromBase64(settings->value("auth/password").toString().toUtf8()));
 	// use Kaidan as resource, if no set
 	if (creds.jidResource == "")
 		setJidResource(QString(APPLICATION_NAME));


### PR DESCRIPTION
When you opened the config file before, you could directly see someone's (or
your own) password, with this it's at least not directly visible to most humans.

Closes #174.