### PR TITLE
Add i18n base file for Weblate

### DIFF
--- a/Kaidan.pro
+++ b/Kaidan.pro
@@ -56,6 +56,7 @@ include(3rdparty/kirigami/kirigami.pri)
 RESOURCES += kaidan_qml.qrc i18n/0_i18n.qrc data/images/images.qrc
 
 TRANSLATIONS += \
+    i18n/base.ts \
     i18n/de.ts \
     i18n/es.ts \
     i18n/fr.ts \

--- a/i18n/base.ts
+++ b/i18n/base.ts
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <source>A simple, user-friendly Jabber/XMPP client</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Source code on GitHub</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BackButton</name>
+    <message>
+        <source>Navigate Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatPage</name>
+    <message>
+        <source>Compose message</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ContextDrawer</name>
+    <message>
+        <source>Actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ForwardButton</name>
+    <message>
+        <source>Navigate Forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GlobalDrawer</name>
+    <message>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Kaidan</name>
+    <message>
+        <source>Could not send message, because not being connected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not add contact, because not being connected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not remove contact, because not being connected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LoginPage</name>
+    <message>
+        <source>Log in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log in to your XMPP account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your Jabber-ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your diaspora*-ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>user@example.org</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>user@diaspora.pod</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RosterAddContactSheet</name>
+    <message>
+        <source>Add new contact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Nickname:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Jabber-ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>user@example.org</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RosterPage</name>
+    <message>
+        <source>Connecting…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add new contact</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RosterRemoveContactSheet</name>
+    <message>
+        <source>Do you really want to delete the contact &lt;%1&gt; from your roster?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete contact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
This adds an empty translation file for creating new translations from the
Weblate WebUI. This won't work fully automated, we will still have to add it to
the QMake and QRC file, so that it'll work correctly with new languages, but the
we could probably grow the number of translators, because not everyone wants to
open an issue on GitHub just to do some translations.