### PR TITLE
Fix release build TLS connection bug!

### DIFF
--- a/src/ServiceDiscoveryManager.cpp
+++ b/src/ServiceDiscoveryManager.cpp
@@ -73,6 +73,8 @@ void ServiceDiscoveryManager::onDisconnect(gloox::ConnectionError error)
 
 bool ServiceDiscoveryManager::onTLSConnect(const gloox::CertInfo &info)
 {
+	// accept; real check is made in ClientWorker
+	return true;
 }
 
 void ServiceDiscoveryManager::setFeaturesAndIdentity()
@@ -114,6 +116,8 @@ void ServiceDiscoveryManager::handleDiscoItems(const gloox::JID& from, const glo
 
 bool ServiceDiscoveryManager::handleDiscoSet(const gloox::IQ& iq)
 {
+	// not handled disco set
+	return false;
 }
 
 void ServiceDiscoveryManager::handleDiscoError(const gloox::JID &from, const gloox::Error *error, int context)


### PR DESCRIPTION
The problem was that the ServiceDiscoveryManager also is a
gloox::ConnectionHandler, but isn't return anything upon a handleTls call, so
this resulted in a true return in gcc (<= 7) in debug mode. gcc (<= 7) in
release mode and gcc-8 and clang in debug mode made it just fail. g++-8
and clang in release mode just gave a segfault.