### PR TITLE
[WIP] Add initial settings page

### DIFF
--- a/kaidan_qml.qrc
+++ b/kaidan_qml.qrc
@@ -2,6 +2,8 @@
 	<qresource prefix="/">
 		<file alias="qml/main.qml">src/qml/main.qml</file>
 		<file alias="qml/RosterPage.qml">src/qml/RosterPage.qml</file>
+		<file alias="qml/SettingsPage.qml">src/qml/SettingsPage.qml</file>
+		<file alias="qml/SettingsPopup.qml">src/qml/SettingsPopup.qml</file>
 		<file alias="qml/LoginPage.qml">src/qml/LoginPage.qml</file>
 		<file alias="qml/ChatPage.qml">src/qml/ChatPage.qml</file>
 		<file alias="qml/AboutDialog.qml">src/qml/AboutDialog.qml</file>
@@ -13,6 +15,7 @@
 		<file alias="qml/elements/MessageCounter.qml">src/qml/elements/MessageCounter.qml</file>
 		<file alias="qml/elements/ChatMessage.qml">src/qml/elements/ChatMessage.qml</file>
 		<file alias="qml/elements/RoundImage.qml">src/qml/elements/RoundImage.qml</file>
+		<file alias="qml/elements/SettingsItem.qml">src/qml/elements/SettingsItem.qml</file>
 
 		<file alias="qtquickcontrols2.conf">misc/qtquickcontrols2.conf</file>
 	</qresource>

--- a/kirigami-icons.qrc
+++ b/kirigami-icons.qrc
@@ -18,5 +18,6 @@
         <file alias="overflow-menu.svg">3rdparty/breeze-icons/icons/actions/22/overflow-menu.svg</file>
         <file alias="system-shutdown.svg">3rdparty/breeze-icons/icons/actions/22/system-shutdown.svg</file>
         <file alias="view-list-icons.svg">3rdparty/breeze-icons/icons/actions/22/view-list-icons.svg</file>
+        <file alias="preferences-other.svg">3rdparty/breeze-icons/icons/actions/22/preferences-other.svg</file>
     </qresource>
 </RCC>

--- a/kirigami-icons.qrc
+++ b/kirigami-icons.qrc
@@ -19,5 +19,6 @@
         <file alias="system-shutdown.svg">3rdparty/breeze-icons/icons/actions/22/system-shutdown.svg</file>
         <file alias="view-list-icons.svg">3rdparty/breeze-icons/icons/actions/22/view-list-icons.svg</file>
         <file alias="preferences-other.svg">3rdparty/breeze-icons/icons/actions/22/preferences-other.svg</file>
+        <file alias="window-close.svg">3rdparty/breeze-icons/icons/actions/16/window-close.svg</file>
     </qresource>
 </RCC>

--- a/src/qml/GlobalDrawer.qml
+++ b/src/qml/GlobalDrawer.qml
@@ -66,7 +66,7 @@ Kirigami.GlobalDrawer {
 		},
 		Kirigami.Action {
 			text: qsTr("Settings")
-			iconName: "systemsettings"
+			iconName: "preferences-other"
 			onTriggered: {
 				// open settings page
 				if (Kirigami.Settings.isMobile)

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -42,7 +42,7 @@ Kirigami.ScrollablePage {
 			visible: Kirigami.Settings.isMobile
 			iconName: "window-close"
 			onTriggered: {
-				pageStack.layers.pop();
+				pageStack.layers.pop()
 			}
 		}
 	}

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -37,6 +37,16 @@ Kirigami.ScrollablePage {
 	anchors.fill: parent
 	title: "Settings"
 
+	actions {
+		main: Kirigami.Action {
+			visible: Kirigami.Settings.isMobile
+			iconName: "window-close"
+			onTriggered: {
+				pageStack.layers.pop();
+			}
+		}
+	}
+
 	ColumnLayout {
 		SettingsItem {
 			name: "Test Item 1"

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -1,7 +1,7 @@
 /*
  *  Kaidan - A user-friendly XMPP client for every device!
  *
- *  Copyright (C) 2017-2018 Kaidan developers and contributors
+ *  Copyright (C) 2018 Kaidan developers and contributors
  *  (see the LICENSE file for a full list of copyright authors)
  *
  *  Kaidan is free software: you can redistribute it and/or modify
@@ -29,51 +29,29 @@
  */
 
 import org.kde.kirigami 2.0 as Kirigami
-import io.github.kaidanim 1.0
+import QtQuick.Layouts 1.3
+import "elements"
 
-Kirigami.GlobalDrawer {
-	id: globalDrawer
-	title: "Kaidan"
-	titleIcon: "kaidan"
-	bannerImageSource: kaidan.getResourcePath("images/banner.png");
-	// make drawer floating (overlay)
-	modal: true
-	// start with closed drawer
-	drawerOpen: false
-	// show open button on the left side
-	handleVisible: true
+Kirigami.ScrollablePage {
+	id: page
+	anchors.fill: parent
+	title: "Settings"
 
-	SettingsPopup {
-		id: settingsPopup
-	}
-
-	actions: [
-		Kirigami.Action {
-			text: qsTr("Log out")
-			iconName: "system-shutdown"
-			onTriggered: {
-				// disconnect (open log in page)
-				kaidan.mainDisconnect(true);
-			}
-		},
-		Kirigami.Action {
-			text: qsTr("About")
-			iconName: "help-about"
-			onTriggered: {
-				// open about sheet
-				aboutDialog.open();
-			}
-		},
-		Kirigami.Action {
-			text: qsTr("Settings")
-			iconName: "systemsettings"
-			onTriggered: {
-				// open settings page
-				if (Kirigami.Settings.isMobile)
-					pageStack.layers.push(settingsPage)
-				else
-					settingsPopup.open();
+	ColumnLayout {
+		SettingsItem {
+			name: "Test Item 1"
+			description: "Test Item Description"
+			onClicked: {
+				
 			}
 		}
-	]
+		SettingsItem {
+			name: "Test Item 2"
+			description: "Test Item Description"
+		}
+		SettingsItem {
+			name: "Test Item 3"
+			description: "Test Item Description"
+		}
+	}
 }

--- a/src/qml/SettingsPopup.qml
+++ b/src/qml/SettingsPopup.qml
@@ -30,6 +30,8 @@
 
 import QtQuick.Controls 2.0 as Controls
 import org.kde.kirigami 2.0 as Kirigami
+import QtQuick.Layouts 1.3
+import QtQuick 2.6
 
 Controls.Popup {
 	id: settingsPopup
@@ -40,9 +42,17 @@ Controls.Popup {
 	height: Kirigami.Units.gridUnit * 30
 	modal: true
 
-	Kirigami.Heading {
-		text: "Settings"
-	}
+	ColumnLayout {
+		Kirigami.Heading {
+			id: heading
+			text: "Settings"
+		}
 
-	SettingsPage {}
+		Item {
+			width: settingsPopup.width
+			height: settingsPopup.height - heading.height
+
+			SettingsPage {}
+		}
+	}
 }

--- a/src/qml/SettingsPopup.qml
+++ b/src/qml/SettingsPopup.qml
@@ -1,7 +1,7 @@
 /*
  *  Kaidan - A user-friendly XMPP client for every device!
  *
- *  Copyright (C) 2017-2018 Kaidan developers and contributors
+ *  Copyright (C) 2018 Kaidan developers and contributors
  *  (see the LICENSE file for a full list of copyright authors)
  *
  *  Kaidan is free software: you can redistribute it and/or modify
@@ -28,52 +28,21 @@
  *  along with Kaidan.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQuick.Controls 2.0 as Controls
 import org.kde.kirigami 2.0 as Kirigami
-import io.github.kaidanim 1.0
 
-Kirigami.GlobalDrawer {
-	id: globalDrawer
-	title: "Kaidan"
-	titleIcon: "kaidan"
-	bannerImageSource: kaidan.getResourcePath("images/banner.png");
-	// make drawer floating (overlay)
+Controls.Popup {
+	id: settingsPopup
+
+	x: (root.width - width) * 0.5 + globalDrawer.width
+	y: (root.height - height) * 0.5
+	width: Kirigami.Units.gridUnit * 30
+	height: Kirigami.Units.gridUnit * 30
 	modal: true
-	// start with closed drawer
-	drawerOpen: false
-	// show open button on the left side
-	handleVisible: true
 
-	SettingsPopup {
-		id: settingsPopup
+	Kirigami.Heading {
+		text: "Settings"
 	}
 
-	actions: [
-		Kirigami.Action {
-			text: qsTr("Log out")
-			iconName: "system-shutdown"
-			onTriggered: {
-				// disconnect (open log in page)
-				kaidan.mainDisconnect(true);
-			}
-		},
-		Kirigami.Action {
-			text: qsTr("About")
-			iconName: "help-about"
-			onTriggered: {
-				// open about sheet
-				aboutDialog.open();
-			}
-		},
-		Kirigami.Action {
-			text: qsTr("Settings")
-			iconName: "systemsettings"
-			onTriggered: {
-				// open settings page
-				if (Kirigami.Settings.isMobile)
-					pageStack.layers.push(settingsPage)
-				else
-					settingsPopup.open();
-			}
-		}
-	]
+	SettingsPage {}
 }

--- a/src/qml/elements/SettingsItem.qml
+++ b/src/qml/elements/SettingsItem.qml
@@ -1,7 +1,7 @@
 /*
  *  Kaidan - A user-friendly XMPP client for every device!
  *
- *  Copyright (C) 2017-2018 Kaidan developers and contributors
+ *  Copyright (C) 2018 Kaidan developers and contributors
  *  (see the LICENSE file for a full list of copyright authors)
  *
  *  Kaidan is free software: you can redistribute it and/or modify
@@ -27,53 +27,47 @@
  *  You should have received a copy of the GNU General Public License
  *  along with Kaidan.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+import QtQuick 2.6
+import QtQuick.Controls 2.0 as Controls
+import QtQuick.Layouts 1.3
 import org.kde.kirigami 2.0 as Kirigami
-import io.github.kaidanim 1.0
 
-Kirigami.GlobalDrawer {
-	id: globalDrawer
-	title: "Kaidan"
-	titleIcon: "kaidan"
-	bannerImageSource: kaidan.getResourcePath("images/banner.png");
-	// make drawer floating (overlay)
-	modal: true
-	// start with closed drawer
-	drawerOpen: false
-	// show open button on the left side
-	handleVisible: true
+Kirigami.BasicListItem {
+	property string name;
+	property string description;
+	property Item ownPage
 
-	SettingsPopup {
-		id: settingsPopup
-	}
+	id: listItem
 
-	actions: [
-		Kirigami.Action {
-			text: qsTr("Log out")
-			iconName: "system-shutdown"
-			onTriggered: {
-				// disconnect (open log in page)
-				kaidan.mainDisconnect(true);
+	reserveSpaceForIcon: false
+	
+	RowLayout {
+		ColumnLayout {
+			Kirigami.Heading {
+				id: nameLabel
+				text: name
+				textFormat: Text.PlainText
+				elide: Text.ElideRight
+				maximumLineCount: 1
+				level: 3
+				Layout.fillWidth: true
+				Layout.maximumHeight: Kirigami.Units.gridUnit * 1.5
 			}
-		},
-		Kirigami.Action {
-			text: qsTr("About")
-			iconName: "help-about"
-			onTriggered: {
-				// open about sheet
-				aboutDialog.open();
+
+			// bottom
+			Controls.Label {
+				id: descriptionLabel
+				Layout.fillWidth: true
+				elide: Text.ElideRight
+				maximumLineCount: 1
+				text: description
+				textFormat: Text.PlainText
+				font.pixelSize: 16
 			}
-		},
-		Kirigami.Action {
-			text: qsTr("Settings")
-			iconName: "systemsettings"
-			onTriggered: {
-				// open settings page
-				if (Kirigami.Settings.isMobile)
-					pageStack.layers.push(settingsPage)
-				else
-					settingsPopup.open();
-			}
+			height: nameLabel.height + descriptionLabel.height
 		}
-	]
+
+		Controls.Switch {
+		}
+	}
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -75,6 +75,7 @@ Kirigami.ApplicationWindow {
 	Component {id: chatPage; ChatPage {}}
 	Component {id: loginPage; LoginPage {}}
 	Component {id: rosterPage; RosterPage {}}
+	Component {id: settingsPage; SettingsPage {}}
 
 	function passiveNotification(text) {
 		showPassiveNotification(text, "long")


### PR DESCRIPTION
I started this earlier already but finally found time to bring it to a pull-requestable state. 
On desktop systems, the settings are displayed as a popup, like in Telegram Desktop. On phones, settings are displayed on a new layer.
Currently no real settings are included.
Ideas for settings:
- [ ] Chat background image
- [ ] XMPP console (although I'd like to hide that in some sort of developer options)

Desktop behaviour:
<img width="300" src="https://user-images.githubusercontent.com/13609393/38470066-0e79dd8a-3b5e-11e8-9efa-a5cfc1935713.png"/>


Mobile behaviour (I'm not yet sure how you can leave the new layer on android...):
<img width="300" src="https://user-images.githubusercontent.com/13609393/38470085-4caafcba-3b5e-11e8-94b1-67641152ea3e.png"/>

