### PR TITLE
Implement XEP-0300: Use of Cryptographic Hash Functions in XMPP

### DIFF
--- a/Kaidan.pro
+++ b/Kaidan.pro
@@ -33,7 +33,8 @@ SOURCES += \
     src/gloox-extensions/bitsofbinarymanager.cpp \
     src/gloox-extensions/bitsofbinarymemorycache.cpp \
     src/gloox-extensions/reference.cpp \
-    src/gloox-extensions/processinghints.cpp
+    src/gloox-extensions/processinghints.cpp \
+    src/gloox-extensions/hash.cpp
 
 HEADERS += \
     src/Database.h \
@@ -68,7 +69,8 @@ HEADERS += \
     src/gloox-extensions/bitsofbinarycache.h \
     src/gloox-extensions/bitsofbinarymemorycache.h \
     src/gloox-extensions/reference.h \
-    src/gloox-extensions/processinghints.h
+    src/gloox-extensions/processinghints.h \
+    src/gloox-extensions/hash.h
 
 
 android: INCLUDEPATH += $$PWD/3rdparty/gloox/include

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,4 +35,5 @@ set(KAIDAN_SOURCES
 	${CURDIR}/gloox-extensions/bitsofbinarymemorycache.cpp
 	${CURDIR}/gloox-extensions/reference.cpp
 	${CURDIR}/gloox-extensions/processinghints.cpp
+	${CURDIR}/gloox-extensions/hash.cpp
 )

--- a/src/gloox-extensions/gloox-extensions.h
+++ b/src/gloox-extensions/gloox-extensions.h
@@ -84,6 +84,28 @@ namespace gloox {
 
 	static const std::string XMLNS_PROCESSINGHINTS = "urn:xmpp:hints";
 	static const int EXT_PROCESSINGHINTS = 4273;
+
+	//
+	// XEP-0300: Use of Cryptographic Hash functions in XMPP
+	//
+
+	static const std::string XMLNS_HASHES_2 = "urn:xmpp:hashes:2";
+	static const int EXT_HASHES = 4274;
+
+	static const std::string XMLNS_HASH_MD5 = "urn:xmpp:hash-function-text-names:md5";
+	static const std::string XMLNS_HASH_SHA_1 = "urn:xmpp:hash-function-text-names:sha-1";
+	static const std::string XMLNS_HASH_SHA_224 = "urn:xmpp:hash-function-text-names:sha-224";
+	static const std::string XMLNS_HASH_SHA_256 = "urn:xmpp:hash-function-text-names:sha-256";
+	static const std::string XMLNS_HASH_SHA_384 = "urn:xmpp:hash-function-text-names:sha-384";
+	static const std::string XMLNS_HASH_SHA_512 = "urn:xmpp:hash-function-text-names:sha-512";
+	static const std::string XMLNS_HASH_SHA3_224 = "urn:xmpp:hash-function-text-names:sha3-224";
+	static const std::string XMLNS_HASH_SHA3_256 = "urn:xmpp:hash-function-text-names:sha3-256";
+	static const std::string XMLNS_HASH_SHA3_384 = "urn:xmpp:hash-function-text-names:sha3-384";
+	static const std::string XMLNS_HASH_SHA3_512 = "urn:xmpp:hash-function-text-names:sha3-512";
+	static const std::string XMLNS_HASH_BLAKE2B_160 = "urn:xmpp:hash-function-text-names:id-blake2b160";
+	static const std::string XMLNS_HASH_BLAKE2B_256 = "urn:xmpp:hash-function-text-names:id-blake2b256";
+	static const std::string XMLNS_HASH_BLAKE2B_384 = "urn:xmpp:hash-function-text-names:id-blake2b384";
+	static const std::string XMLNS_HASH_BLAKE2B_512 = "urn:xmpp:hash-function-text-names:id-blake2b512";
 }
 
 #endif // GLOOXEXTS_H__

--- a/src/gloox-extensions/hash.cpp
+++ b/src/gloox-extensions/hash.cpp
@@ -1,0 +1,79 @@
+/*
+ *  Kaidan - A user-friendly XMPP client for every device!
+ *
+ *  Copyright (C) 2018 Kaidan developers and contributors
+ *  (see the LICENSE file for a full list of copyright authors)
+ *
+ *  Kaidan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  In addition, as a special exception, the author of Kaidan gives
+ *  permission to link the code of its release with the OpenSSL
+ *  project's "OpenSSL" library (or with modified versions of it that
+ *  use the same license as the "OpenSSL" library), and distribute the
+ *  linked executables. You must obey the GNU General Public License in
+ *  all respects for all of the code used other than "OpenSSL". If you
+ *  modify this file, you may extend this exception to your version of
+ *  the file, but you are not obligated to do so.  If you do not wish to
+ *  do so, delete this exception statement from your version.
+ *
+ *  Kaidan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kaidan.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "hash.h"
+#include "gloox-extensions.h"
+
+using namespace gloox;
+
+Hash::Hash(std::string algo, const std::string& hash)
+	: StanzaExtension(EXT_HASHES), m_algo(hash), m_hash(hash),
+	m_valid(m_algo.length())
+{
+}
+
+Hash::Hash(const Tag* tag)
+	: StanzaExtension(EXT_HASHES), m_valid(false)
+{
+	if (tag->findAttribute("xmlns") != XMLNS_HASHES || !tag->hasAttribute("algo"))
+		return;
+
+	m_algo = tag->findAttribute("algo");
+
+	if (tag->name() == "hash") {
+		m_hash = tag->cdata();
+		m_valid = m_algo.length() && m_hash.length();
+	} else if (tag->name() == "hash-used") {
+		m_valid = m_algo.length();
+	}
+}
+
+Tag* Hash::tag() const
+{
+	if (!m_valid)
+		return new Tag("hash");
+
+	if (m_hash.length()) {
+		Tag* tag = new Tag("hash", XMLNS, XMLNS_HASHES);
+		tag->addAttribute("algo", m_algo);
+		tag->addCData(m_hash);
+		return tag;
+	}
+
+	Tag* tag = new Tag("hash-used", XMLNS, XMLNS_HASHES);
+	tag->addAttribute("algo", m_algo);
+	return tag;
+}
+
+const std::string& Hash::filterString() const
+{
+	static const std::string filter = "/*/*[@xmlns='" + XMLNS_HASHES + "']";
+	return filter;
+}

--- a/src/gloox-extensions/hash.h
+++ b/src/gloox-extensions/hash.h
@@ -1,0 +1,121 @@
+/*
+ *  Kaidan - A user-friendly XMPP client for every device!
+ *
+ *  Copyright (C) 2018 Kaidan developers and contributors
+ *  (see the LICENSE file for a full list of copyright authors)
+ *
+ *  Kaidan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  In addition, as a special exception, the author of Kaidan gives
+ *  permission to link the code of its release with the OpenSSL
+ *  project's "OpenSSL" library (or with modified versions of it that
+ *  use the same license as the "OpenSSL" library), and distribute the
+ *  linked executables. You must obey the GNU General Public License in
+ *  all respects for all of the code used other than "OpenSSL". If you
+ *  modify this file, you may extend this exception to your version of
+ *  the file, but you are not obligated to do so.  If you do not wish to
+ *  do so, delete this exception statement from your version.
+ *
+ *  Kaidan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kaidan.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HASH_H__
+#define HASH_H__
+
+#include <gloox/stanzaextension.h>
+#include <gloox/tag.h>
+#include <string>
+
+namespace gloox {
+	/**
+	 * @class Hash An implementation of 'Use of Cryptographic Hash Functions in
+	 * XMPP' (@xep{0300}) as a StanzaExtension.
+	 *
+	 * XEP Version: 0.5
+	 *
+	 * @author Linus Jahn <lnj@kaidan.im>
+	 * @since 1.0.21
+	 */
+	class GLOOX_API Hash : public gloox::StanzaExtension
+	{
+	public:
+		/**
+		 * Default constructor
+		 *
+		 * @param algo The hash algorithm used
+		 * @param hash The hash binary value encoded as base64
+		 */
+		Hash(std::string algo, const std::string &hash = EmptyString);
+
+		/**
+		 * Construct from XML Tag
+		 */
+		Hash(const Tag *tag);
+
+		/**
+		 * Clone the StanzaExtension
+		 */
+		virtual StanzaExtension* clone() const
+		{
+			return new Hash(*this);
+		}
+
+		/**
+		 * Get the XML tag
+		 */
+		virtual Tag* tag() const;
+
+		/**
+		 * Create a new instance
+		 */
+		virtual StanzaExtension* newInstance(const Tag* tag) const
+		{
+			return new Hash(tag);
+		}
+
+		/**
+		 * Returns the filter string for filtering by the client
+		 */
+		virtual const std::string& filterString() const;
+
+		/**
+		 * Check if is valid
+		 */
+		bool valid() const
+		{
+			return m_valid;
+		}
+
+		/**
+		 * Get hash algorithm
+		 */
+		std::string algorithm() const
+		{
+			return m_algo;
+		}
+
+		/**
+		 * Get full hash value as base64 binary
+		 */
+		std::string value() const
+		{
+			return m_hash;
+		}
+
+	private:
+		bool m_valid;
+		std::string m_algo;
+		std::string m_hash;
+	};
+}
+
+#endif // PROCESSINGHINTS_H__


### PR DESCRIPTION
This implements the hash and hash-used stanza extensions of XEP-0300 in version
0.5. There are no new hash algorithms in this commit, this will probably the job
of the crypto library in gloox.