### PR TITLE
travis: Fix that apt cache is empty at begin

### DIFF
--- a/utils/travis/dependencies.sh
+++ b/utils/travis/dependencies.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -e
 . utils/travis/common.sh
 
+if [ $PLATFORM != "ubuntu-touch" ]; then
+	sudo apt update
+fi
+
 echo "*****************************************"
 echo "Fetching dependencies"
 echo "^^^^^^^^^^^^^^^^^^^^^"


### PR DESCRIPTION
Due to a change at travis-ci, apt update won't be executed at container start
up. Possibilities are to enable it in the travis.yml explicitly again or to do
it manually. Doing it manually is better for us, because we don't need another
apt update at start up for ubuntu touch builds.