### PR TITLE
avatars: Optimize vCard fetchment, Use SHA1 hashes locally

### DIFF
--- a/src/AvatarFileStorage.cpp
+++ b/src/AvatarFileStorage.cpp
@@ -43,7 +43,7 @@ AvatarFileStorage::AvatarFileStorage(QObject *parent) : QObject(parent)
 		cacheDir.mkpath("avatars");
 
 	// search for the avatar list file (hash <-> jid)
-	QString avatarFilePath = getAvatarPath("avatar_list.sha3-256");
+	QString avatarFilePath = getAvatarPath("avatar_list.sha1");
 
 	try {
 		// check if file was found
@@ -82,12 +82,13 @@ AvatarFileStorage::~AvatarFileStorage()
 {
 }
 
-AvatarFileStorage::AddAvatarResult AvatarFileStorage::addAvatar(const QString &jid, const QByteArray &avatar)
+AvatarFileStorage::AddAvatarResult AvatarFileStorage::addAvatar(const QString &jid,
+	const QByteArray &avatar)
 {
 	AddAvatarResult result;
 
 	// generate a hexadecimal hash of the raw avatar
-	result.hash = QString(QCryptographicHash::hash(avatar, QCryptographicHash::Sha3_256).toHex());
+	result.hash = QString(QCryptographicHash::hash(avatar, QCryptographicHash::Sha1).toHex());
 	// set the new hash and the `hasChanged` tag
 	if (jidAvatarMap[jid] != result.hash) {
 		jidAvatarMap[jid] = result.hash;
@@ -153,7 +154,7 @@ bool AvatarFileStorage::hasAvatarHash(const QString& hash) const
 void AvatarFileStorage::saveAvatarsFile()
 {
 	QFile file(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
-		QDir::separator() + QString("avatars") + QDir::separator() + QString("avatar_list.sha3-256"));
+		QDir::separator() + QString("avatars") + QDir::separator() + QString("avatar_list.sha1"));
 	if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
 		return;
 

--- a/src/AvatarFileStorage.h
+++ b/src/AvatarFileStorage.h
@@ -44,7 +44,7 @@ public:
 	~AvatarFileStorage();
 
 	struct AddAvatarResult {
-		/* SHA3-256 HEX Hash */
+		/* SHA1 HEX Hash */
 		QString hash;
 		/* If the hash for the JID has changed */
 		bool hasChanged = false;
@@ -52,12 +52,39 @@ public:
 		bool newWritten = false;
 	};
 
+	/**
+	 * Add a new avatar in binary form that will be saved in a cache location
+	 *
+	 * @param jid The JID the avatar belongs to
+	 * @param avatar The binary avatar (not in base64)
+	 */
 	AddAvatarResult addAvatar(const QString &jid, const QByteArray &avatar);
+
+	/**
+	 * Returns the path to the avatar of the JID
+	 */
 	QString getAvatarPathOfJid(const QString &jid) const;
+
+	/**
+	 * Returns true if there an avatar saved for the given hash
+	 *
+	 * @param hash The SHA1 hash of the binary avatar
+	 */
 	bool hasAvatarHash(const QString &hash) const;
+
+	/**
+	 * Returns the path to a given hash
+	 */
 	QString getAvatarPath(const QString &hash) const;
 
+	/**
+	 * Returns the hash of the avatar of the JID
+	 */
 	Q_INVOKABLE QString getHashOfJid(const QString &jid) const;
+
+	/**
+	 * Returns a file URL to the avatar image of a given JID
+	 */
 	Q_INVOKABLE QString getAvatarUrl(const QString &jid) const;
 
 signals:

--- a/src/RosterUpdater.cpp
+++ b/src/RosterUpdater.cpp
@@ -62,7 +62,10 @@ void RosterUpdater::handleRoster(const gloox::Roster &roster)
 		QString name = QString::fromStdString(item.second->name());
 
 		contactList[jid] = name;
-		vCardManager->fetchVCard(jid);
+
+		// fetch avatar from vCard, if no avatar in cache
+		if (kaidan->getAvatarStorage()->getHashOfJid(jid).isEmpty())
+			vCardManager->fetchVCard(jid);
 	}
 
 	// replace current contacts with new ones from server


### PR DESCRIPTION
I made a mistake and somehow forgot to also check if the hash in the vCard based
avatars presence actually differs from the local hash saved for the JID. Thus,
before the vCards were fetched unnecessarily often. To do this I had to use
SHA1 hashes (instead of SHA3-256) for identifying the avatars.

Now the vCards only get fetched on start up, if there's no local avatar saved
for the JID, so if somebody has no avatar in their vCard the vCard will be
fetched every time at start up. Unfortunately this can't be further optimized,
but on the other hand that are just some bytes and I think that's totally ok.