### PR TITLE
ubuntu-touch: Remove dependency of QQC2

### DIFF
--- a/utils/build-click.sh
+++ b/utils/build-click.sh
@@ -22,17 +22,11 @@ install_deb() {
 
 install_dependencies() {
 	KIRIGAMI_VERSION="5.44.0-2"
-	QQC2_VERSION="5.9.3-0ubports3"
 	GLOOX_VERSION="1.0.20-1+16.04+xenial+build1"
 
 	echo "I: Installing Kirigami 2"
 	for PKG in qml-module-org-kde-kirigami2 kirigami2-dev libkf5kirigami2-5; do
 		install_deb http://snapshot.debian.org/archive/debian/20180430T215634Z/pool/main/k/kirigami2 ${PKG} ${KIRIGAMI_VERSION}
-	done
-
-	echo "I: Installing QtQuick Controls 2"
-	for PKG in qml-module-qtquick-controls2 libqt5quickcontrols2-5 qtquickcontrols2-5-dev qml-module-qtquick-templates2 qml-module-qt-labs-platform libqt5quicktemplates2-5 libqt5quicktemplates2-5; do
-		install_deb https://repo.ubports.com/pool/xenial/main/q/qtquickcontrols2-opensource-src ${PKG} ${QQC2_VERSION}
 	done
 
 	echo "I: Installing gloox"


### PR DESCRIPTION
It's integrated to Ubuntu Touch now ;)